### PR TITLE
docs(README): update hot-reloading code for rxjs-spy-devtools-plugin

### DIFF
--- a/packages/rxjs-spy-devtools-plugin/README.md
+++ b/packages/rxjs-spy-devtools-plugin/README.md
@@ -17,11 +17,9 @@ spy.plug(devtoolsPlugin);
 
 // We must teardown the spy if we're hot-reloading:
 if (module.hot) {
-  if (module.hot) {
-    module.hot.dispose(() => {
-      spy.teardown();
-    });
-  }
+  module.hot.dispose(() => {
+    spy.teardown();
+  });
 }
 ```
 


### PR DESCRIPTION
The check for module.hot was done twice, resulting in an unnecessary condition.